### PR TITLE
fix: track core v2.5.8 — drop now-public poll declarations

### DIFF
--- a/rayforce-sys/build.rs
+++ b/rayforce-sys/build.rs
@@ -18,7 +18,7 @@ use std::process::Command;
 /// these in lockstep with a `rayforce-sys` release. Override at build time with
 /// the `RAYFORCE_REPO` / `RAYFORCE_REF` (and `_Q_` variants) env vars.
 const RAYFORCE_REPO: &str = "https://github.com/RayforceDB/rayforce.git";
-const RAYFORCE_REF: &str = "v2.5.1";
+const RAYFORCE_REF: &str = "v2.5.8";
 const RAYFORCE_Q_REPO: &str = "https://github.com/RayforceDB/rayforce-q.git";
 const RAYFORCE_Q_REF: &str = "2.0.0";
 

--- a/rayforce-sys/wrapper.h
+++ b/rayforce-sys/wrapper.h
@@ -38,11 +38,11 @@ ray_t* ray_de(ray_t* bytes);
 /* src/core/runtime.c — last per-VM error message (set alongside a RAY_ERROR) */
 const char* ray_error_msg(void);
 
-/* src/core/poll.h + runtime.h — the IPC client requires a poll object on the
- * runtime before connecting (ray_poll_t is opaque; use void*). */
-void* ray_poll_create(void);
-void* ray_runtime_get_poll(void);
-void  ray_runtime_set_poll(void* poll);
+/* The poll object the IPC client needs (ray_poll_create / ray_runtime_get_poll
+ * / ray_runtime_set_poll) is exported by the public header as of core v2.5.8,
+ * so it is no longer hand-declared here. ray_poll_create now returns the typed
+ * `ray_poll_t*` rather than the old `void*` — see the cast in
+ * rayforce/src/ipc.rs::ensure_poll. */
 
 #ifdef __cplusplus
 }

--- a/rayforce/src/ipc.rs
+++ b/rayforce/src/ipc.rs
@@ -13,8 +13,11 @@ use std::marker::PhantomData;
 /// Ensure the runtime has a poll object (required before connecting).
 unsafe fn ensure_poll() {
     if sys::ray_runtime_get_poll().is_null() {
+        // Since core v2.5.8 the public header types `ray_poll_create` as
+        // `ray_poll_t*`, while `ray_runtime_set_poll` still takes `void*` —
+        // so the handle needs an explicit cast on the way through.
         let p = sys::ray_poll_create();
-        sys::ray_runtime_set_poll(p);
+        sys::ray_runtime_set_poll(p.cast());
     }
 }
 


### PR DESCRIPTION
Core v2.5.8 exports the poll object API (ray_poll_create, ray_runtime_get_poll, ray_runtime_set_poll) from the public rayforce.h. wrapper.h still hand-declared all three, and bindgen now fails on ray_poll_create — the public header types it ray_poll_t* where wrapper.h had void*, and the two conflict.

Drop the three hand-declarations (they are redundant with the public header) and bump the pinned RAYFORCE_REF from v2.5.1 to v2.5.8 so a fresh crates.io build clones a core that actually exports them.

ray_poll_create now binds as ray_poll_t* rather than void*, so ensure_poll casts the handle on the way into ray_runtime_set_poll, which still takes void*.

Verified: cargo build + cargo test green against a local v2.5.8 checkout, and the embedding consumer (landing) builds and its scenario suite passes.